### PR TITLE
Package Adapted to Changes in the Glue Package as Part of the Update to Version 1.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: glueformula
 Type: Package
 Title: String interpolation to build regression formulas
-Version: 0.1.0
+Version: 0.1.1
 Author: Sebastian Kranz
 Maintainer: Sebastian Kranz <sebastian.kranz@uni-ulm.de>
 Description: 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,6 +1,6 @@
 export("gf")
 export("varnames_snippet")
-importFrom(glue,glue)
+importFrom(glue,glue_data)
 importFrom("methods", "is")
 importFrom("utils", "capture.output")
 

--- a/R/gf.R
+++ b/R/gf.R
@@ -52,7 +52,7 @@ gf = function(form, values=list(), enclos=parent.frame(), as.formula=TRUE, form.
     paste0(val, collapse=collapse)
   })
   names(vals) = vars
-  res = glue::glue_data(.x = vals, form)
+  res = glue_data(.x = vals, form)
   if (!as.formula) {
     return(res)
   }

--- a/R/gf.R
+++ b/R/gf.R
@@ -52,7 +52,7 @@ gf = function(form, values=list(), enclos=parent.frame(), as.formula=TRUE, form.
     paste0(val, collapse=collapse)
   })
   names(vals) = vars
-  res = glue_data(.x = vals, form)
+  res = glue::glue_data(.x = vals, form)
   if (!as.formula) {
     return(res)
   }

--- a/R/gf.R
+++ b/R/gf.R
@@ -52,7 +52,7 @@ gf = function(form, values=list(), enclos=parent.frame(), as.formula=TRUE, form.
     paste0(val, collapse=collapse)
   })
   names(vals) = vars
-  res = glue(form, .envir = vals)
+  res = glue_data(.x = vals, form)
   if (!as.formula) {
     return(res)
   }


### PR DESCRIPTION
With the update to version 1.8.0, the following [change](https://glue.tidyverse.org/news/index.html) was made to the `glue`package, among others:

> The .envir argument to [glue()](https://glue.tidyverse.org/reference/glue.html) and [glue_data()](https://glue.tidyverse.org/reference/glue.html) really must be an environment now, as documented. Previously a list-ish object worked in some cases (by accident, not really by design).

Since in line 55 `res = glue(form, .envir = vals)` the list-ish object `vals` is to be passed, an adjustment is now necessary.

> When you need to lookup values in a list-ish object, use glue_data(.x =) ([#308](https://github.com/tidyverse/glue/issues/308), [#317](https://github.com/tidyverse/glue/issues/317)). Ditto for [glue_sql()](https://glue.tidyverse.org/reference/glue_sql.html) and [glue_data_sql()](https://glue.tidyverse.org/reference/glue_sql.html).

Consequently, we would like to replace `glue()` with `glue_data()`.

Note: `NAMESPACE` (imported functions) and `DESCRIPTION` (version number) are updated accordingly.
